### PR TITLE
created the billboards data table with reuseable comtents

### DIFF
--- a/app/(dashboard)/[storeId]/(routes)/billboards/components/cell-action.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/billboards/components/cell-action.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// import statements
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { BillboardColumn } from "./columns";
+import { Button } from "@/components/ui/button";
+import { Copy, Edit, MoreHorizontal, Trash } from "lucide-react";
+import toast from "react-hot-toast";
+import { useParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import axios from "axios";
+import { AlertModal } from "@/components/modals/alert-modal";
+
+// Props for the cell action component
+interface CellActionProps {
+    data: BillboardColumn // Data for the billboard
+}
+
+// Cell action component
+export const CellAction: React.FC<CellActionProps> = ({
+    data
+}: {
+    data: BillboardColumn
+}) => {
+    
+    const router = useRouter(); // Next.js router hook
+    const params = useParams(); // Parameters from the URL
+
+    const [open, setOpen] = useState(false); // State for modal visibility
+    const [loading, setLoading] = useState(false); // State for loading status
+
+    // Function to copy billboard ID to clipboard
+    const onCopy = (id: string) => {
+        navigator.clipboard.writeText(id);
+        toast.success("Billboard Id copied to the clipboard.");
+    }
+
+    // Function to handle billboard deletion
+    const onDelete = async() => {
+        try{
+            // Set loading status to true and call delete api to delete the given billboard
+            setLoading(true);
+            await axios.delete(`/api/${params.storeId}/billboards/${data.id}`);
+            router.refresh();
+            toast.success("Billboard Deleted.");
+        } catch (error) {
+            toast.error("Make sure you remove categories using this billboard first.");
+        } finally{
+            setLoading(false);
+            setOpen(false); // Close delete modal
+        }
+    }
+
+    // Render the component
+    return (
+        <>
+            {/* Alert modal for delete confirmation */}
+            <AlertModal 
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            onConfirm={onDelete}
+            loading={loading}
+            />
+            {/* Dropdown menu for actions */}
+            <DropdownMenu>
+                {/* Dropdown menu trigger */}
+                <DropdownMenuTrigger asChild>
+                    {/* Button to trigger dropdown menu */}
+                    <Button variant="ghost" className="h-8 w-8 p-0">
+                        <span className="sr-only">Open menu</span>
+                        <MoreHorizontal className="h-4 w-4"/>
+                    </Button>
+                </DropdownMenuTrigger>
+                {/* Dropdown menu content */}
+                <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>
+                        Actions
+                    </DropdownMenuLabel>
+                    {/* Copy ID action */}
+                    <DropdownMenuItem onClick={() => onCopy(data.id)}>
+                        <Copy className="mr-2 h-4 w-4"/>
+                        Copy Id
+                    </DropdownMenuItem>
+                     {/* Edit action */}                
+                    <DropdownMenuItem onClick={() => router.push(`/${params.storeId}/billboards/${data.id}`)}>
+                        <Edit className="mr-2 h-4 w-4"/>
+                        Edit
+                    </DropdownMenuItem>
+                    {/* Delete action */}
+                    <DropdownMenuItem onClick={() => setOpen(true)}>
+                        <Trash className="mr-2 h-4 w-4"/>
+                        Delete
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </>
+    );
+};

--- a/app/(dashboard)/[storeId]/(routes)/billboards/page.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/billboards/page.tsx
@@ -1,12 +1,37 @@
 // import statements
+import prismadb from "@/lib/prismadb";
+import { format } from "date-fns";
 import { BillboardClient } from "./components/client";
+import { BillboardColumn } from "./components/columns";
 
 // Functional component for the BillboardsPage
-const BillboardsPage = () => {
+const BillboardsPage = async ({
+    params
+}: {
+    params: { storeId: string }
+}) => {
+    // getting all the billboards connected to the store id in descending order
+    const billboards = await prismadb.billboard.findMany({
+        where: {
+            storeId: params.storeId
+        },
+        orderBy: {
+            createdAt: 'desc'
+        }
+    });
+
+    // creating the billboard column data structure to match the data table settings
+    const formattedBillboards: BillboardColumn[] = billboards.map((item) => ({
+        id: item.id,
+        label: item.label,
+        createdAt: format(item.createdAt, "MMMM do, yyyy")
+
+    }));
+
     return (
         <div className="flex-col"> {/* Container for the page */}
             <div className="flex-1 space-y-4 p-8 pt-6"> {/* Container for content */}
-                <BillboardClient /> {/* Rendering the BillboardClient component */}
+                <BillboardClient data={formattedBillboards}/> {/* Rendering the BillboardClient component which includes the data table so passing in formatted columns page */}
             </div>
         </div>
     );

--- a/components/ui/api-list.tsx
+++ b/components/ui/api-list.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+// import statements
+import { useOrigin } from "@/hooks/use-origin";
+import { useParams } from "next/navigation";
+import { APiAlert } from "@/components/ui/api-alert";
+
+// things used to describe the API used in the showing the API routes on different pages
+interface ApiListProps {
+    entityName: string;
+    entityIdName: string;
+}
+
+export const ApiList: React.FC<ApiListProps> = ({
+    entityName,
+    entityIdName
+}) => {
+    // getting the storeId from params and url from origin
+    const params = useParams();
+    const origin = useOrigin();
+
+    // baseurl for all api routes created
+    const baseUrl = `${origin}/api/${params.storeId}`;
+
+    // creating multiple API Alerts to showcase the multiple API routes created
+    return (
+        <>
+            <APiAlert 
+            title="GET"
+            variant="public"
+            description={`${baseUrl}/${entityName}`}
+            />
+            <APiAlert 
+            title="GET"
+            variant="public"
+            description={`${baseUrl}/${entityName}/{${entityIdName}}`}
+            />
+            <APiAlert 
+            title="POST"
+            variant="admin"
+            description={`${baseUrl}/${entityName}`}
+            />
+            <APiAlert 
+            title="PATCH"
+            variant="admin"
+            description={`${baseUrl}/${entityName}/{${entityIdName}}`}
+            />
+            <APiAlert 
+            title="DELETE"
+            variant="admin"
+            description={`${baseUrl}/${entityName}/{${entityIdName}}`}
+            />
+        </>
+    );
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,0 +1,132 @@
+"use client"
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input"
+
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+// data table created from shadcn modified
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  searchKey: string; // search key to filter based on different topics
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  searchKey,
+}: DataTableProps<TData, TValue>) {
+
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+        []
+    )
+      
+    const table = useReactTable({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        onColumnFiltersChange: setColumnFilters,
+        getFilteredRowModel: getFilteredRowModel(),
+        state: {
+            columnFilters,
+        }
+    })
+
+    return (
+        <div>
+            <div className="flex items-center py-4">
+                <Input
+                placeholder="Search"
+                value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ""}
+                onChange={(event) =>
+                    table.getColumn(searchKey)?.setFilterValue(event.target.value)
+                }
+                className="max-w-sm"
+                />
+            </div>
+            <div className="rounded-md border">
+            <Table>
+                <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                        return (
+                        <TableHead key={header.id}>
+                            {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                                )}
+                        </TableHead>
+                        )
+                    })}
+                    </TableRow>
+                ))}
+                </TableHeader>
+                <TableBody>
+                {table.getRowModel().rows?.length ? (
+                    table.getRowModel().rows.map((row) => (
+                    <TableRow
+                        key={row.id}
+                        data-state={row.getIsSelected() && "selected"}
+                    >
+                        {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                        ))}
+                    </TableRow>
+                    ))
+                ) : (
+                    <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                        No results.
+                    </TableCell>
+                    </TableRow>
+                )}
+                </TableBody>
+            </Table>
+            </div>
+            <div className="flex items-center justify-end space-x-2 py-4">
+            <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            >
+            Previous
+            </Button>
+            <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            >
+            Next
+            </Button>
+        </div>
+        </div>
+    )
+}


### PR DESCRIPTION
In this commit, I have done the following:
- modified app/(dashboard)/[storeId]/(routes)/billboards/page.tsx to hold the client for billboards which was edited to hold the data table and the API list.
- app/(dashboard)/[storeId]/(routes)/billboards/components/cell-action.tsx was created to add an action beside each billboard which consisted of copy, edit and delete.
- created components/ui/api-list.tsx to display all the API routes for an entity.
- modified the components/ui/data-table.tsx from shadcn to better fit the web app.